### PR TITLE
Ensure date, not time, is sent to GA

### DIFF
--- a/app/wrappers/wakes/google_analytics_api_wrapper.rb
+++ b/app/wrappers/wakes/google_analytics_api_wrapper.rb
@@ -38,8 +38,8 @@ class Wakes::GoogleAnalyticsApiWrapper
       :api_method => api.data.ga.get,
       :parameters => {
         'ids' => "ga:#{ENV['GOOGLE_ANALYTICS_PROFILE_ID']}",
-        'start-date' => start_date.to_s,
-        'end-date' => end_date.to_s,
+        'start-date' => format_date(start_date),
+        'end-date' => format_date(end_date),
         'metrics' => 'ga:pageviews',
         'dimensions' => 'ga:pagePath',
         'filters' => PrepareFiltersForGAPagePath.new(path).filters,
@@ -107,6 +107,10 @@ class Wakes::GoogleAnalyticsApiWrapper
     when 'User Rate Limit Exceeded' then raise UserRateLimitExceededError
     else raise message
     end
+  end
+
+  def format_date(date)
+    date.to_date.to_s
   end
 
   class DailyLimitExceededError < StandardError; end

--- a/spec/wrappers/wakes/google_analytics_api_wrapper_spec.rb
+++ b/spec/wrappers/wakes/google_analytics_api_wrapper_spec.rb
@@ -3,8 +3,10 @@ require 'rails_helper'
 RSpec.describe Wakes::GoogleAnalyticsApiWrapper do
   describe '#get_pageviews_for_path' do
     # Describes this view: https://www.google.com/analytics/web/?hl=en#report/content-pages/a1853263w3269662p8231065/%3F_u.date00%3D20140101%26_u.date01%3D20141231%26explorer-table.plotKeys%3D%5B%5D%26explorer-table.advFilter%3D%5B%5B0%2C%22analytics.pagePath%22%2C%22RE%22%2C%22%5E%2Fabout(%5C%5C%3F%7C%24)%22%2C0%5D%5D%26explorer-table.rowCount%3D100/
-    it 'returns the total pageviews for the given date range' do
-      pageviews = subject.get_pageviews_for_path('/about', :start_date => '2014-01-01', :end_date => '2014-12-31')
+    it 'returns the total pageviews for the given date range, converting date input to date strings' do
+      pageviews = subject.get_pageviews_for_path('/about',
+                                                 :start_date => '2014-01-01T00:00:00+00:00',
+                                                 :end_date => '2014-12-31T00:00:00+00:00')
 
       expect(pageviews).to eq 78_891
     end


### PR DESCRIPTION
Fix for https://app.honeybadger.io/projects/36767/faults/22950932/6f886e8c-b868-11e5-8d1b-ce80306a61e6#notice-summary

Happens because JSONB stores datetime, not date. If you want a date from a datetime, you need to cast it. I've chosen to do the cast at the wrapper level, but there are alternatives...