### PR TITLE
Retain query component for Wakes locations

### DIFF
--- a/lib/wakes/matchers.rb
+++ b/lib/wakes/matchers.rb
@@ -17,12 +17,10 @@ RSpec::Matchers.define :have_wakes_graph do |canonical_location:, legacy_locatio
   end
 
   failure_message do |wakes_resource|
-    wakes_legacy_locations_array = wakes_resource.legacy_locations.map do |x|
-      URIFromLocationString.get_host_and_path(x)
-    end.sort
+    legacy_locations_array = legacy_locations.map { |x| URIFromLocationString.get_host_and_path(x) }.sort
     message = "Expected canonical location \"#{canonical_location}\","
     message += " got canonical location \"#{wakes_resource.canonical_location.label}\"\n"
-    message += "Expected legacy locations #{legacy_locations.sort}, "
-    message + "got legacy locations #{wakes_legacy_locations_array}"
+    message += "Expected legacy locations #{legacy_locations_array}, "
+    message + "got legacy locations #{wakes_resource.legacy_locations.pluck(:host, :path).sort}"
   end
 end

--- a/lib/wakes/matchers.rb
+++ b/lib/wakes/matchers.rb
@@ -11,7 +11,7 @@ RSpec::Matchers.define :have_wakes_graph do |canonical_location:, legacy_locatio
 
     wakes_resource.locations.count == expected_location_count &&
       wakes_resource.canonical_location.host == URIFromLocationString.generate(canonical_location).host &&
-      wakes_resource.canonical_location.path == URIFromLocationString.generate(canonical_location).path &&
+      wakes_resource.canonical_location.path == URIFromLocationString.generate(canonical_location).request_uri &&
       wakes_resource.legacy_locations.pluck(:host, :path).sort ==
         legacy_locations.map { |x| URIFromLocationString.get_host_and_path(x) }.sort
   end

--- a/lib/wakes/uri_from_location_string.rb
+++ b/lib/wakes/uri_from_location_string.rb
@@ -8,6 +8,6 @@ class URIFromLocationString
 
   def self.get_host_and_path(location_string)
     uri = generate(location_string)
-    [uri.host, uri.path]
+    [uri.host, uri.request_uri]
   end
 end

--- a/spec/lib/wakes/redirect_mapper_spec.rb
+++ b/spec/lib/wakes/redirect_mapper_spec.rb
@@ -216,4 +216,13 @@ RSpec.describe Wakes::RedirectMapper do
       end
     end
   end
+
+  context 'handles query strings' do
+    it 'retains the query strings in the wakes graph' do
+      described_class.new '/source?param=p1', '/target?key=value', 'New Label'
+
+      expect(Wakes::Location.find_by(:host => nil, :path => '/source?param=p1').resource)
+        .to have_wakes_graph(:canonical_location => '/target?key=value', :legacy_locations => ['/source?param=p1'])
+    end
+  end
 end


### PR DESCRIPTION
Fall-out from [PR#22 Add host field to wakes locations](https://github.com/desiringgod/wakes/pull/22). 
https://trello.com/c/noYZ6n6j/2020-add-hostname-support-to-wakes-locations

Ensure that query component is retained when creating redirect rules or matching wakes graphs. Without this, we lose support for redirection of URIs like `www.domain.com/resource?lang=es` to `www.domain.com/es/resource`. 