### PR TITLE
Use update_attribute instead of save to skip validations

### DIFF
--- a/app/models/wakes/resource.rb
+++ b/app/models/wakes/resource.rb
@@ -29,13 +29,13 @@ class Wakes::Resource < ActiveRecord::Base
   end
 
   def update_facebook_count
-    self.facebook_count = locations.sum("COALESCE((wakes_locations.document ->> 'facebook_count')::int, 0)")
-    save!
+    update_attribute(:facebook_count,
+                     locations.sum("COALESCE((wakes_locations.document ->> 'facebook_count')::int, 0)"))
   end
 
   def update_twitter_count
-    self.twitter_count = locations.sum("COALESCE((wakes_locations.document ->> 'twitter_count')::int, 0)")
-    save!
+    update_attribute(:twitter_count,
+                     locations.sum("COALESCE((wakes_locations.document ->> 'twitter_count')::int, 0)"))
   end
 
   private


### PR DESCRIPTION
The goal here is to avoid unrelated validation failures when updating metrics.