### PR TITLE
Enable manual enqueuing of social metrics updates; support other hosts

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,6 +24,35 @@ Or install it yourself as:
 
 TODO: Write usage instructions here
 
+### Social metrics updating
+
+Wakes can query Google Analytics and Facebook to get updated pageview and share counts, respectively, for wakes locations. Wakes relies on several environment variables:
+
+- `ENV['DEFAULT_HOST']`
+- `ENV['FACEBOOK_API_TOKEN']`
+- `ENV['GOOGLE_ANALYTICS_START_DATE']` - the date from which you wish to start pageview counts
+- `ENV['GOOGLE_PRIVATE_KEY']`
+- `ENV['GOOGLE_CLIENT_EMAIL']`
+- `ENV['GOOGLE_ANALYTICS_PROFILE_ID']`
+
+In addition, if you are using Wakes to query Google Analytics data across multiple GA profiles, you should specify these profile IDs by hostname in a `configure` block. This can be helpful if you are using Wakes to aggregate metrics for resources accessible across multiple hosts. Each host will have its own GA profile, but Wakes will still aggregate the social metrics to a single wakes resource.
+
+Here is an example `config/initializers/wakes.rb`:
+
+```ruby
+Wakes.configure do |config|
+  config.ga_profiles = {
+    'default' => ENV['GOOGLE_ANALYTICS_PROFILE_ID'],
+    'some-other-subdomain.myhost.com' => ENV['GOOGLE_ANALYTICS_SJ_PROFILE_ID']
+  }
+end
+```
+
+During metrics updating, Wakes will look up the GA profile, using the host of the wakes location as the key. If the wakes location's `host` is blank or if it matches `ENV['DEFAULT_HOST']`, then wakes will use the `default` profile from the configure block.
+
+Note that Wakes locations with a non-default, non-blank host _must_ have a corresponding Google Analytics profile in the configuration block in order to update.
+
+
 ## Development
 
 After checking out the repo, run `bin/setup` to install dependencies. Then, run `rake spec` to run the tests. You can also run `bin/console` for an interactive prompt that will allow you to experiment.

--- a/app/models/concerns/wakes/metrics/facebook.rb
+++ b/app/models/concerns/wakes/metrics/facebook.rb
@@ -7,6 +7,10 @@ module Wakes
       included do
         store_accessor :document, :facebook_count, :facebook_count_updated_at
 
+        def enqueue_facebook_count_update
+          Wakes::UpdateFacebookMetricsJob.perform_later(self)
+        end
+
         def self.ordered_for_facebook_updates
           order("document->'facebook_count_updated_at' ASC NULLS FIRST")
         end

--- a/app/models/concerns/wakes/metrics/google_analytics_pageviews.rb
+++ b/app/models/concerns/wakes/metrics/google_analytics_pageviews.rb
@@ -7,6 +7,10 @@ module Wakes
       included do
         store_accessor :document, :pageview_count, :pageview_count_updated_through, :pageview_count_checked_at
 
+        def enqueue_pageview_count_update
+          Wakes::GoogleAnalyticsPageviewJob.perform_later(self)
+        end
+
         def self.enqueue_pageview_count_updates(count)
           ordered_for_analytics_worker.needs_analytics_update.limit(count).each do |location|
             Wakes::GoogleAnalyticsPageviewJob.perform_later(location)

--- a/app/models/concerns/wakes/metrics/google_analytics_pageviews.rb
+++ b/app/models/concerns/wakes/metrics/google_analytics_pageviews.rb
@@ -11,6 +11,14 @@ module Wakes
           Wakes::GoogleAnalyticsPageviewJob.perform_later(self)
         end
 
+        def google_analytics_profile_id
+          if host.blank? || (host == ENV['DEFAULT_HOST'])
+            Wakes.configuration.ga_profiles['default']
+          else
+            Wakes.configuration.ga_profiles[host]
+          end
+        end
+
         def self.enqueue_pageview_count_updates(count)
           ordered_for_analytics_worker.needs_analytics_update.limit(count).each do |location|
             Wakes::GoogleAnalyticsPageviewJob.perform_later(location)

--- a/app/services/wakes/pageview_count_updater_service.rb
+++ b/app/services/wakes/pageview_count_updater_service.rb
@@ -61,9 +61,12 @@ class Wakes::PageviewCountUpdaterService
     # usually, they will be equal
     raise EndDateEarlierThanStartDateError, 'end_date is earlier than start date' if end_date < start_date
 
-    @pageviews ||= Wakes::GoogleAnalyticsApiWrapper.new.get_pageviews_for_path(location.path,
-                                                                               :start_date => start_date,
-                                                                               :end_date => end_date)
+    @pageviews ||= Wakes::GoogleAnalyticsApiWrapper
+                   .new
+                   .get_pageviews_for_path(location.path,
+                                           :start_date => start_date,
+                                           :end_date => end_date,
+                                           :profile_id => location.google_analytics_profile_id)
   end
 
   class EndDateEarlierThanStartDateError < StandardError; end;

--- a/app/wrappers/wakes/google_analytics_api_wrapper.rb
+++ b/app/wrappers/wakes/google_analytics_api_wrapper.rb
@@ -7,9 +7,9 @@ class Wakes::GoogleAnalyticsApiWrapper
 
   # More precisely, this sums up the pageviews for this particular path and
   # any other paths with query strings
-  def get_pageviews_for_path(path, start_date:, end_date:)
+  def get_pageviews_for_path(path, start_date:, end_date:, profile_id: Wakes.configuration.ga_profiles['default'])
     authorized_analytics_service.get_ga_data(
-      "ga:#{ENV['GOOGLE_ANALYTICS_PROFILE_ID']}",
+      "ga:#{profile_id}",
       format_date(start_date),
       format_date(end_date),
       'ga:pageviews',

--- a/lib/wakes/configuration.rb
+++ b/lib/wakes/configuration.rb
@@ -15,9 +15,13 @@ module Wakes
 
   class Configuration
     attr_accessor :enabled
+    attr_accessor :ga_profiles
 
     def initialize
       @enabled = true
+      @ga_profiles = {
+        'default' => ENV['GOOGLE_ANALYTICS_PROFILE_ID']
+      }
     end
   end
 end


### PR DESCRIPTION
In support of https://trello.com/c/ISv4bpe7/2099-update-sj-social-metrics-in-wakes