### PR TITLE
Move Pageview Count Checked At update code

### DIFF
--- a/app/services/wakes/pageview_count_updater_service.rb
+++ b/app/services/wakes/pageview_count_updater_service.rb
@@ -9,13 +9,12 @@ class Wakes::PageviewCountUpdaterService
   def update_pageview_count
     if pageviews_since_last_update.positive?
       update_location_pageview_count && update_resource_aggregate_count && update_wakeable_aggregate_count
+      # Yes, this will often result in two update operations
+      # Right now, code expressiveness and comprehension seem more important than performance
+      location.update(:pageview_count_checked_at => Time.zone.now)
     else
       false
     end
-  ensure
-    # Yes, this will often result in two update operations
-    # Right now, code expressiveness and comprehension seem more important than performance
-    location.update(:pageview_count_checked_at => Time.zone.now)
   end
 
   def update_location_pageview_count


### PR DESCRIPTION
@benhutton This seemed like the simplest solution.

Practically speaking, in the update pageview counts block:
```
update_location_pageview_count && update_resource_aggregate_count && update_wakeable_aggregate_count
```
aside from the GA error, the only other way this block will fail is probably if there is a SQL connection error. In the case of the GA error, we don't want the `checked_at` time to update, so this seems like the best way to handle it.
