### PR TITLE
Update Rubocop Config to Allow Rescue Modifier

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -190,6 +190,13 @@ Style/Next:
   Description: 'Use `next` to skip iteration instead of a condition at the end.'
   StyleGuide: 'https://github.com/bbatsov/ruby-style-guide#no-nested-conditionals'
   Enabled: false
+  
+# Disable this because it's a really useful short form way of dealing with exceptions in certain scenarios.
+# Leave it up to the developer to make that decision.
+Style/RescueModifier:
+  Description: 'Avoid using rescue in its modifier form.'
+  StyleGuide: https://github.com/bbatsov/ruby-style-guide#no-rescue-modifiers
+  Enabled: false
 
 # Keep things fitting nicely on github
 Metrics/LineLength:


### PR DESCRIPTION
The rescue modifier can be a useful tool and can be used at the developer's discretion.