### PR TITLE
Fix NoMethodError in FacebookCountUpdaterService

### DIFF
--- a/app/models/wakes/resource.rb
+++ b/app/models/wakes/resource.rb
@@ -21,6 +21,10 @@ class Wakes::Resource < ActiveRecord::Base
 
   validates :label, :presence => true
 
+  def wakeable_type=(class_name)
+    super(class_name.constantize.base_class.to_s)
+  end
+
   def to_s
     <<-EOS
   #{Wakes.color(:yellow, "(#{id}) #{label}")}

--- a/spec/models/concerns/wakeable_spec.rb
+++ b/spec/models/concerns/wakeable_spec.rb
@@ -217,6 +217,14 @@ RSpec.describe Wakeable do
         expect(wakeable.wakes_resource.label).to eq('A Wakeable Model')
         expect(wakeable.wakes_resource).to have_wakes_graph(:canonical_location => '/a-wakeable-model')
       end
+
+      # See "Polymorphic Associations" under http://api.rubyonrails.org/classes/ActiveRecord/Associations/ClassMethods.html
+      it 'overwrites the wakeable_type with the base class' do
+        wakeable = child_model_class.create(:title => 'A Wakeable Model')
+        wakeable.wakes_resource.wakeable_type = child_model_class.to_s
+
+        expect(wakeable.wakes_resource.wakeable_type).to eq child_model_class.base_class.to_s
+      end
     end
 
     context 'parent and child both have wakes' do


### PR DESCRIPTION
The `wakeable` polymorphic association on `Wakes::Resource` does not behave correctly when `wakeable` is an STI subclass. For example, when `wakeable` is an STI subclass, the following returns nil:

`wakes_resource.wakeable.wakes_resource`

This is because Rails expects the `_type` field for polymorphic associations to equal the STI base class, not the subclass. See "Polymorphic associations" here: http://api.rubyonrails.org/classes/ActiveRecord/Associations/ClassMethods.html

This pattern happens here: https://github.com/desiringgod/wakes/blob/develop/app/models/concerns/wakeable/has_one.rb#L21