### PR TITLE
Remove unnecessary disabling of Metrics/BlockLength

### DIFF
--- a/wakes.gemspec
+++ b/wakes.gemspec
@@ -3,8 +3,6 @@
 lib = File.expand_path('../lib', __FILE__)
 $LOAD_PATH.unshift(lib) unless $LOAD_PATH.include?(lib)
 require 'wakes/version'
-
-# rubocop:disable Metrics/BlockLength
 Gem::Specification.new do |spec|
   spec.name          = 'wakes'
   spec.version       = Wakes::VERSION


### PR DESCRIPTION
This happens automatically when I run `rubocop -a`