### PR TITLE
Allow following and capturing of redirecting external URLs into Wakes

### DIFF
--- a/lib/wakes.rb
+++ b/lib/wakes.rb
@@ -7,6 +7,7 @@ require 'wakes/configuration'
 require 'wakes/model_configuration'
 require 'wakes/redirect_mapper'
 require 'wakes/middleware/redirector'
+require 'wakes/external_redirect_mapper'
 
 require 'redis-rails'
 require 'redis-namespace'
@@ -56,6 +57,10 @@ module Wakes
     Wakes::Resource.find_each do |resource|
       resource.update_attribute(:legacy_paths_in_redis, nil)
     end
+  end
+
+  def self.resource_for_external_url(url)
+    ExternalRedirectMapper.new(url).resource
   end
 
   COLORS = {

--- a/lib/wakes/configuration.rb
+++ b/lib/wakes/configuration.rb
@@ -16,12 +16,14 @@ module Wakes
   class Configuration
     attr_accessor :enabled
     attr_accessor :ga_profiles
+    attr_accessor :internal_hosts # Hosts to exclude when adding external redirects to Wakes
 
     def initialize
       @enabled = true
       @ga_profiles = {
         'default' => ENV['GOOGLE_ANALYTICS_PROFILE_ID']
       }
+      @internal_hosts = nil
     end
   end
 end

--- a/lib/wakes/external_redirect_mapper.rb
+++ b/lib/wakes/external_redirect_mapper.rb
@@ -1,0 +1,94 @@
+# frozen_string_literal: true
+
+module Wakes
+  MAX_REDIRECTS = 10
+
+  class ExternalRedirectMapper
+    def initialize(url)
+      @redirecting_uris = []
+      @uri = URI(url)
+    end
+
+    def resource
+      resolve_target&.resource
+    end
+
+    private
+
+    # rubocop:disable MethodLength
+    def resolve_target
+      target_location = Wakes::Location.find_by(:host => host(@uri), :path => path(@uri))
+
+      redirects = 0
+      while target_location.nil? && expanded_url(@uri).present? && redirects < MAX_REDIRECTS
+        @redirecting_uris << @uri
+        target_location = Wakes::Location
+                          .find_by(:host => host(expanded_url(@uri)), :path => path(expanded_url(@uri)))
+                          &.resource&.canonical_location
+        @uri = URI(expanded_url(@uri))
+        redirects += 1
+      end
+      setup_redirects(target_location)
+      target_location
+    end
+    # rubocop:enable MethodLength
+
+    def setup_redirects(target_location)
+      return if target_location.nil?
+      @redirecting_uris
+        .compact
+        .reject { |source| is_internal_host? host(source) }
+        .each { |source| Wakes.redirect source.to_s, target_location.path_or_url }
+    end
+
+    def expanded_url(uri)
+      @expanded_url ||= {}
+      @expanded_url[uri] ||= begin
+        new_url = Net::HTTP.new(uri.host, uri.port)
+                           .tap { |http| http.use_ssl = uri.scheme == 'https' }
+                           .get(uri.path == '' ? '/' : uri.path)
+                           .header['location']
+        absolute_url(uri.scheme, uri.host, URI.encode(new_url.to_s))
+      end
+    end
+
+    def absolute_url(scheme, host, path)
+      if path.present? && URI(path).host.nil?
+        "#{scheme}://#{host}#{path}"
+      else
+        path
+      end
+    end
+
+    def host(url)
+      host = URI(url).host
+      host = host == ENV['DEFAULT_HOST'] ? nil : host
+      host
+    end
+
+    def path(url)
+      uri = URI(url)
+
+      # remove trailing slashes except for root
+      path = if ['/', ''].include? uri.path
+               '/'
+             else
+               uri.path.sub(%r{/$}, '')
+             end
+
+      params = Rack::Utils.parse_nested_query uri.query
+      params['lang'].present? ? "#{path}?lang=#{params['lang']}" : path
+    end
+
+    def is_internal_host?(host)
+      return true if host.nil?
+      if Wakes.configuration.internal_hosts.is_a?(Regexp)
+        host =~ Wakes.configuration.internal_hosts
+      elsif Wakes.configuration.internal_hosts.is_a?(Array)
+        Wakes.configuration.internal_hosts.any? { |s| s.casecmp(host).zero? }
+      else
+        host == Wakes.configuration.internal_hosts
+      end
+    end
+  end
+end

--- a/spec/lib/wakes/external_redirect_mapper_spec.rb
+++ b/spec/lib/wakes/external_redirect_mapper_spec.rb
@@ -1,0 +1,89 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.describe Wakes::ExternalRedirectMapper do
+  describe 'Wakes.configuration.internal_hosts' do
+    let!(:resource) { create(:resource, :label => 'Only Resource') }
+    let!(:target) { create(:location, :canonical => true, :path => '/target', :resource => resource) }
+
+    before do
+      stub_request(:any, 't.co/some-url')
+        .to_return(:status => [301, 'Moved Permanently'],
+                   :headers => {:location => 'http://otherdomain.org/another-url'})
+      stub_request(:any, 'otherdomain.org/another-url')
+        .to_return(:status => [301, 'Moved Permanently'],
+                   :headers => {:location => 'http://fr.mydomain.org'})
+      stub_request(:any, 'fr.mydomain.org')
+        .to_return(:status => [301, 'Moved Permanently'],
+                   :headers => {:location => "http://www.mydomain.org/non-wakes-redirect"})
+      stub_request(:any, 'www.mydomain.org/non-wakes-redirect')
+        .to_return(:status => [301, 'Moved Permanently'],
+                   :headers => {:location => "http://www.mydomain.org/target"})
+      stub_request(:any, 'www.mydomain.org/target')
+
+      ENV['DEFAULT_HOST'] = 'www.mydomain.org'
+    end
+
+    context 'as a regular expression' do
+      before do
+        Wakes.configure do |config|
+          config.internal_hosts = /^([a-z0-9.\-]*[.])?mydomain\.org$/i
+        end
+      end
+
+      it 'adds only external URLs to the wakes graph' do
+        described_class.new('http://t.co/some-url').resource
+
+        expect(resource).to have_wakes_graph(:canonical_location => '/target',
+                                             :legacy_locations => ['t.co/some-url', 'otherdomain.org/another-url'])
+      end
+    end
+
+    context 'as an array' do
+      before do
+        Wakes.configure do |config|
+          config.internal_hosts = ['mydomain.org', 'otherdomain.org']
+        end
+      end
+
+      it 'adds only external URLs to the wakes graph' do
+        described_class.new('http://t.co/some-url').resource
+
+        expect(resource).to have_wakes_graph(:canonical_location => '/target',
+                                             :legacy_locations => ['t.co/some-url', 'fr.mydomain.org/'])
+      end
+    end
+
+    context 'as a string' do
+      before do
+        Wakes.configure do |config|
+          config.internal_hosts = 'fr.mydomain.org'
+        end
+      end
+
+      it 'adds only external URLs to the wakes graph' do
+        described_class.new('http://t.co/some-url').resource
+
+        expect(resource).to have_wakes_graph(
+          :canonical_location => '/target',
+          :legacy_locations => ['t.co/some-url', 'otherdomain.org/another-url']
+        )
+      end
+    end
+
+    context 'unspecified' do
+      before do
+        Wakes.configuration = Wakes::Configuration.new # reset from any previous examples
+      end
+      it 'adds only external URLs to the wakes graph' do
+        described_class.new('http://t.co/some-url').resource
+
+        expect(resource).to have_wakes_graph(
+          :canonical_location => '/target',
+          :legacy_locations => ['t.co/some-url', 'otherdomain.org/another-url', 'fr.mydomain.org/']
+        )
+      end
+    end
+  end
+end


### PR DESCRIPTION
This PR provides an API to have Wakes follow external URLs (e.g., shortened URLs, but could be any URL managed outside of Wakes) through zero or more redirects, and if a URL ends up pointing to a `Wakes::Resource` we manage, then track the URL as a non-canonical location.

Our use case is to be able to associate individual tweets (which contain shortened URLs) to the `Wakes::Resources` they may happen to link to, but there may be other uses, too.