### PR TITLE
Update ga method and spec

### DIFF
--- a/app/wrappers/wakes/google_analytics_api_wrapper.rb
+++ b/app/wrappers/wakes/google_analytics_api_wrapper.rb
@@ -16,7 +16,7 @@ class Wakes::GoogleAnalyticsApiWrapper
   private
 
   def get_page(page, start_date, end_date, profile_id)
-    authorized_analytics_service.get_ga_data(
+    authorized_analytics_service.get_datum_ga(
       "ga:#{profile_id}",
       format_date(start_date),
       format_date(end_date),

--- a/spec/wrappers/wakes/google_analytics_api_wrapper_spec.rb
+++ b/spec/wrappers/wakes/google_analytics_api_wrapper_spec.rb
@@ -6,7 +6,9 @@ RSpec.describe Wakes::GoogleAnalyticsApiWrapper do
   describe '#get_page_of_pageviews' do
     let(:rows) { [['/path', 151], ['/path/2', 500]] }
     let(:results) { double('Results', :rows => rows, :items_per_page => 2) }
-    let(:analytics_service) { double('AnalyticsService', :get_ga_data => results) }
+    let(:analytics_service) do
+      instance_double(Google::Apis::AnalyticsV3::AnalyticsService, :get_datum_ga => results)
+    end
     let(:start_date) { Time.new(2017, 10, 10).to_date }
     let(:end_date) { Time.new(2017, 12, 12).to_date }
 
@@ -14,8 +16,8 @@ RSpec.describe Wakes::GoogleAnalyticsApiWrapper do
       allow(subject).to receive(:authorized_analytics_service).and_return(analytics_service)
     end
 
-    it 'calls #get_ga_data on GA' do
-      expect(analytics_service).to receive(:get_ga_data).with(
+    it 'calls #get_datum_ga on GA' do
+      expect(analytics_service).to receive(:get_datum_ga).with(
         'ga:profile',
         '2017-10-10',
         '2017-12-12',
@@ -39,7 +41,7 @@ RSpec.describe Wakes::GoogleAnalyticsApiWrapper do
 
     context 'page is not 1' do
       it 'correctly calculates the new start index' do
-        expect(analytics_service).to receive(:get_ga_data).with(
+        expect(analytics_service).to receive(:get_datum_ga).with(
           any_args,
           a_hash_including(:start_index => 2001)
         )


### PR DESCRIPTION
This is what happens when you "generate" a hundred APIs for your gem:

![image](https://user-images.githubusercontent.com/61645/26897303-1291f014-4b96-11e7-944e-6785a1f9b7cd.png)

https://github.com/google/google-api-ruby-client/blob/master/generated/google/apis/analytics_v3/service.rb#L114

I'm pretty sure all that changed is the name