### PR TITLE
Truncate to first 5 params for target calculation

### DIFF
--- a/lib/wakes/middleware/redirector.rb
+++ b/lib/wakes/middleware/redirector.rb
@@ -152,7 +152,7 @@ module Wakes
       # ]
       #
       def potential_query_strings
-        params = request.query_string.split('&')
+        params = request.query_string.split('&').first(5)
         @potential_query_strings ||= (0..params.size).to_a.reverse.map do |n|
           params.permutation(n).map { |permutation| permutation.join('&') }
         end.flatten


### PR DESCRIPTION
Without this, a request with many params will lock up the server process
trying to calculate the permutations.

This is safe, because params we care about for calculation are listed
first and we never have many.