### PR TITLE
Enable redirects when rule’s host is within a specified list

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -8,3 +8,7 @@ ruby '2.5.0'
 gemspec
 
 gem 'byebug'
+
+group :test do
+  gem 'pg', '< 1' # fixed in the next rails release: https://github.com/rails/rails/pull/31671
+end

--- a/app/models/concerns/wakes/redirectors.rb
+++ b/app/models/concerns/wakes/redirectors.rb
@@ -18,7 +18,9 @@ module Wakes
         return unless canonical_location.present?
         legacy_locations.reload
         legacy_paths_in_redis = legacy_locations.map do |legacy_location|
-          Wakes::REDIS.set(legacy_location.path, canonical_location.path_or_url) if legacy_location.host.blank?
+          if Wakes.configuration.hosts_to_redirect.include?(legacy_location.host)
+            Wakes::REDIS.set(legacy_location.path, canonical_location.path_or_url)
+          end
           legacy_location.path
         end
         update_attribute(:legacy_paths_in_redis, legacy_paths_in_redis)

--- a/lib/wakes/configuration.rb
+++ b/lib/wakes/configuration.rb
@@ -16,12 +16,19 @@ module Wakes
   class Configuration
     attr_accessor :enabled
     attr_accessor :ga_profiles
+    attr_accessor :additional_hosts_to_redirect
 
     def initialize
       @enabled = true
       @ga_profiles = {
         'default' => ENV['GOOGLE_ANALYTICS_PROFILE_ID']
       }
+      @additional_hosts_to_redirect = []
+    end
+
+    def hosts_to_redirect
+      # Including nil allows Wakes to always apply redirects with no host specified
+      @additional_hosts_to_redirect + [nil]
     end
   end
 end


### PR DESCRIPTION
Adds the ability to configure additional domains for which you want Wakes to apply redirect rules. 

Wakes does not attempt to match the host name in the _request_. This PR just allows Wakes to process redirects for locations that have a `host` attribute specified.

Here's the use case. Assuming there are no collisions between paths on the two hosts, this allows you to collapse `subdomain.domain.com` into `www.domain.com` by
1. redirecting `subdomain.domain.com` to `www.domain.com` at the DNS level
2. mapping locations from `subdomain` to locations on `www`
3. adding `subdomain.domain.com` to the Wakes `domains` config parameter.

Why? This lets you keep metrics active for legacy locations that were once on separate domains, but that are now are served off the same host with Wakes redirect rules.