### PR TITLE
Updates to match with URI host changes in ruby 3.2.1

### DIFF
--- a/lib/wakes/matchers.rb
+++ b/lib/wakes/matchers.rb
@@ -12,9 +12,9 @@ RSpec::Matchers.define :have_wakes_graph do |canonical_location:, legacy_locatio
     canonical_location_uri = URIFromLocationString.generate(canonical_location)
 
     wakes_resource.locations.count == expected_location_count &&
-      wakes_resource.canonical_location.try(:host) == canonical_location_uri.try(:host) &&
+      wakes_resource.canonical_location.try(:host).presence == canonical_location_uri.try(:host).presence &&
       wakes_resource.canonical_location.try(:path) == canonical_location_uri.try(:request_uri) &&
-      wakes_resource.legacy_locations.pluck(:host, :path).sort ==
+      wakes_resource.legacy_locations.pluck(:host, :path).map { |e| e.map(&:presence) }.sort ==
         legacy_locations.map { |x| URIFromLocationString.get_host_and_path(x) }.sort
   end
 

--- a/lib/wakes/uri_from_location_string.rb
+++ b/lib/wakes/uri_from_location_string.rb
@@ -8,6 +8,6 @@ class URIFromLocationString
 
   def self.get_host_and_path(location_string)
     uri = generate(location_string)
-    [uri.host, uri.request_uri]
+    [uri.host.presence, uri.request_uri.presence]
   end
 end


### PR DESCRIPTION
In ruby 3.2.1, `URI#host` for `'https///example.com'` is an empty string, while in previous versions of ruby it is `nil`.


```
# ruby 3.1.0
URI('http:///authors/john-s-piper/messages').host
# => nil

# ruby 3.2.1
URI('http:///authors/john-s-piper/messages').host
# => ''
```

The updates here make the code agnostic to these differences. 