### PR TITLE
Limit retry count on querying Google Analytics API

### DIFF
--- a/app/services/wakes/get_path_counts_for_date_range_service.rb
+++ b/app/services/wakes/get_path_counts_for_date_range_service.rb
@@ -37,13 +37,19 @@ module Wakes
     def load_next_page
       @page_number ||= 0
       @page_number += 1
+      attempt = 0
 
       begin
         logger.info "Going to request page #{@page_number} for #{start_date} - #{end_date} from Google Analytics"
+        attempt += 1
         google_analytics.get_page_of_pageviews(@page_number, :start_date => start_date, :end_date => end_date)
       rescue Google::Apis::Error => err
         block_for_page(@page_number, err)
-        retry
+        if attempt < 4
+          retry
+        else
+          raise err
+        end
       end
     end
 

--- a/app/services/wakes/get_path_counts_for_date_range_service.rb
+++ b/app/services/wakes/get_path_counts_for_date_range_service.rb
@@ -40,8 +40,8 @@ module Wakes
       attempt = 0
 
       begin
-        logger.info "Going to request page #{@page_number} for #{start_date} - #{end_date} from Google Analytics"
         attempt += 1
+        logger.info "Attempt number #{attempt}: Querying GA for page #{@page_number} for #{start_date} - #{end_date}"
         google_analytics.get_page_of_pageviews(@page_number, :start_date => start_date, :end_date => end_date)
       rescue Google::Apis::Error => err
         block_for_page(@page_number, err)


### PR DESCRIPTION
Keep retry count to 3